### PR TITLE
Fixed issue with string concatenation

### DIFF
--- a/src/onelogin/aws-assume-role/aws-assume-role.py
+++ b/src/onelogin/aws-assume-role/aws-assume-role.py
@@ -115,7 +115,7 @@ def get_saml_response(client, username_or_email, password, app_id, onelogin_subd
             if mfa_verify_info is None:
                 print("-----------------------------------------------------------------------")
                 for index, device in enumerate(devices):
-                    print(" " + index + " | " + device.type)
+                    print(" " + str(index) + " | " + device.type)
 
                 print("-----------------------------------------------------------------------")
                 print("\nSelect the desired MFA Device [0-%s]: " % (len(devices) - 1))


### PR DESCRIPTION
This PR fixes following error:
```
Traceback (most recent call last):
  File "src/onelogin/aws-assume-role/aws-assume-role.py", line 301, in <module>
    main()
  File "src/onelogin/aws-assume-role/aws-assume-role.py", line 207, in main
    result = get_saml_response(client, username_or_email, password, app_id, onelogin_subdomain, mfa_verify_info)
  File "src/onelogin/aws-assume-role/aws-assume-role.py", line 118, in get_saml_response
    print(" " + index + " | " + device.type)
TypeError: must be str, not int
```

Checked on Python 3.6.2.