### PR TITLE
Add AWS region, username, app ID and subdomain as optional command-line arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ Where:
 - Provide the OneLogin's App ID to identify the AWS app
 - Provide the domain of your OneLogin's instance.
 
+_Note: If you're bored typing your username, App ID, subdomain or AWS region every time,
+you can specify these parameters as command-line arguments instead._
+
 With that data, a SAMLResponse is retrieved. And possible AWS Role are retrieved.
 
 #### Step 2. Select AWS Role to be assumed.

--- a/README.md
+++ b/README.md
@@ -71,8 +71,13 @@ Where:
 - Provide the OneLogin's App ID to identify the AWS app
 - Provide the domain of your OneLogin's instance.
 
-_Note: If you're bored typing your username, App ID, subdomain or AWS region every time,
-you can specify these parameters as command-line arguments instead._
+_Note: If you're bored typing your
+username (`--onelogin-username`),
+App ID (`--onelogin-app-id`),
+subdomain (`--onelogin-subdomain`) or
+AWS region (`--aws-region`)
+every time, you can specify these parameters as command-line arguments and
+the tool won't ask for them any more._
 
 With that data, a SAMLResponse is retrieved. And possible AWS Role are retrieved.
 

--- a/src/onelogin/aws-assume-role/aws-assume-role.py
+++ b/src/onelogin/aws-assume-role/aws-assume-role.py
@@ -192,7 +192,7 @@ def main():
 
     mfa_verify_info = None
     role_arn = principal_arn = None
-    default_aws_region = 'us-east-1'
+    default_aws_region = 'us-west-2'
 
     config_file_writer = None
     botocore_config = botocore.client.Config(signature_version=botocore.UNSIGNED)

--- a/src/onelogin/aws-assume-role/aws-assume-role.py
+++ b/src/onelogin/aws-assume-role/aws-assume-role.py
@@ -52,6 +52,8 @@ def get_options():
                       help="OneLogin app id")
     parser.add_option("-d", "--onelogin-subdomain", dest="subdomain", type="string",
                       help="OneLogin subdomain")
+    parser.add_option("--aws-region", dest="aws_region", type="string",
+                      help="AWS region to use")
 
     (options, args) = parser.parse_args()
 
@@ -255,8 +257,11 @@ def main():
 
         if i == 0:
             # AWS Region
-            print("\nAWS Region (" + default_aws_region + "): ")
-            aws_region = sys.stdin.readline().strip()
+            if options.aws_region:
+                aws_region = options.aws_region
+            else:
+                print("\nAWS Region (" + default_aws_region + "): ")
+                aws_region = sys.stdin.readline().strip()
             if not aws_region or aws_region == "-":
                 aws_region = default_aws_region
 

--- a/src/onelogin/aws-assume-role/aws-assume-role.py
+++ b/src/onelogin/aws-assume-role/aws-assume-role.py
@@ -13,6 +13,7 @@ import botocore
 from lxml import etree as ET
 from onelogin.api.client import OneLoginClient
 from optparse_mooi import CompactColorHelpFormatter
+
 from writer import ConfigFileWriter
 
 
@@ -124,8 +125,9 @@ def get_saml_response(client, username_or_email, password, app_id, onelogin_subd
                     print(" " + str(index) + " | " + device.type)
 
                 print("-----------------------------------------------------------------------")
-                print("\nSelect the desired MFA Device [0-%s]: " % (len(devices) - 1))
+
                 if len(devices) > 1:
+                    print("\nSelect the desired MFA Device [0-%s]: " % (len(devices) - 1))
                     device_selection = int(sys.stdin.readline().strip())
                 else:
                     device_selection = 0


### PR DESCRIPTION
For better UX, make it possible to provide static parameters via command-line argument and ask for dynamic inputs only (like passwords, MFA code).
If something is not passed as argument, let default to the old behaviour: ask for it interactively.