### PR TITLE
Fix "UnboundLocalError: local variable ip referenced before assignment"

### DIFF
--- a/src/onelogin/aws-assume-role/aws-assume-role.py
+++ b/src/onelogin/aws-assume-role/aws-assume-role.py
@@ -100,7 +100,7 @@ def str2bool(v):
 
 
 def get_client(options):
-    client_id = client_secret = None
+    client_id = client_secret = ip = None
 
     if options.client_id is not None and options.client_secret is not None:
         client_id = options.client_id


### PR DESCRIPTION
Fix an uninitialised var which causes:
```Traceback (most recent call last):
  File "/Users/xxx/onelogin-python-aws-assume-role/src/onelogin/aws-assume-role/aws-assume-role.py", line 558, in <module>
    main()
  File "/Users/xxx/onelogin-python-aws-assume-role/src/onelogin/aws-assume-role/aws-assume-role.py", line 345, in main
    client = get_client(options)
  File "/Users/xxx/onelogin-python-aws-assume-role/src/onelogin/aws-assume-role/aws-assume-role.py", line 123, in get_client
    if ip:
UnboundLocalError: local variable 'ip' referenced before assignment
```