### PR TITLE
Add password CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,13 @@ AWS region (`--aws-region`)
 every time, you can specify these parameters as command-line arguments and
 the tool won't ask for them any more._
 
+_Note: Specifying your password directly with `--onelogin-password` is bad practice,
+you should use that flag together with password managers, eg. with the OSX Keychain:
+`--onelogin-password $(security find-generic-password -a $USER -s onelogin -w)`,
+so your password won't be saved in you command line history.
+Please note that your password **will** be visible in your process list,
+if you use this flag (as the expanded command line arguments are part of the name of the process)._
+
 With that data, a SAMLResponse is retrieved. And possible AWS Role are retrieved.
 
 #### Step 2. Select AWS Role to be assumed.

--- a/src/onelogin/aws-assume-role/aws-assume-role.py
+++ b/src/onelogin/aws-assume-role/aws-assume-role.py
@@ -54,6 +54,9 @@ def get_options():
     parser.add_argument("-u", "--onelogin-username",
                         dest="username",
                         help="OneLogin username (email address)")
+    parser.add_argument("--onelogin-password",
+                        dest="password",
+                        help="OneLogin password")
     parser.add_argument("-a", "--onelogin-app-id",
                         dest="app_id",
                         help="OneLogin app id")
@@ -384,7 +387,10 @@ def main():
                     print("OneLogin Username: ")
                     username_or_email = sys.stdin.readline().strip()
 
-                password = getpass.getpass("\nOneLogin Password: ")
+                if options.password:
+                    password = options.password
+                else:
+                    password = getpass.getpass("\nOneLogin Password: ")
 
                 if options.app_id:
                     app_id = options.app_id


### PR DESCRIPTION
using `--onelogin-password pwd` is a bad practice, but in tandem with password managers, it can be very useful (like `--onelogin-password $(security find-generic-password -a $USER -s onelogin -w)` for the OSX keychain)