### PR TITLE
Fix for #26

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     author='OneLogin',
     author_email='support@onelogin.com',
     license='MIT',
-    url='https://github.com/onelogin/onelogin-python-aws-cli-assume-role',
+    url='https://github.com/onelogin/onelogin-python-aws-assume-role',
     packages=[
         'aws_assume_role'
     ],

--- a/src/aws_assume_role/aws_assume_role.py
+++ b/src/aws_assume_role/aws_assume_role.py
@@ -14,7 +14,7 @@ from botocore.exceptions import ClientError
 from lxml import etree as ET
 from onelogin.api.client import OneLoginClient
 
-from writer import ConfigFileWriter
+from aws_assume_role.writer import ConfigFileWriter
 
 
 MFA_ATTEMPS_FOR_WARNING = 3

--- a/src/aws_assume_role/version.py
+++ b/src/aws_assume_role/version.py
@@ -1,3 +1,3 @@
 #! /usr/bin/env python
 
-__version__ = '1.5.0'
+__version__ = '1.5.1'


### PR DESCRIPTION
This fixes issue #26 when run in Docker. `writer` is module in the package `aws_assume_role` and should always be called as `from aws_assume_role import writer` or `from aws_assume_role.writer import ConfigFileWriter`.