### PR TITLE
Caching saml

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,13 +152,13 @@ Activate then the environment
 Then run 
 
 ```sh
-> pip setup install
+> python setup install
 ```
 
 or
 
 ```sh
-> setup.py develop
+> python setup.py develop
 ```
 
 to install dependencies.

--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ You can also make it interactive, with the `-x` or `--interactive`option, and at
 
 The selection of the AWS account and Role can be also be done with the --aws-account-id and --aws-role-name parameters.
 
+If you plan to execute the script several times over different Accounts/Roles of the user and you want to cache the SAMLResponse, set the --cache-saml option
+
 For more info execute:
 
 ```sh

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         '': 'src',
     },
     install_requires=[
-        'boto3==1.7.84',
+        'boto3>=1.7.84',
         'onelogin==1.5.0'
     ],
     entry_points={

--- a/src/aws_assume_role/aws_assume_role.py
+++ b/src/aws_assume_role/aws_assume_role.py
@@ -16,8 +16,7 @@ from datetime import datetime
 from base64 import b64decode
 from onelogin.api.client import OneLoginClient
 
-from writer import ConfigFileWriter
-#from aws_assume_role.writer import ConfigFileWriter
+from aws_assume_role.writer import ConfigFileWriter
 
 
 MFA_ATTEMPS_FOR_WARNING = 3

--- a/src/aws_assume_role/version.py
+++ b/src/aws_assume_role/version.py
@@ -1,3 +1,3 @@
 #! /usr/bin/env python
 
-__version__ = '1.5.1'
+__version__ = '1.6.0'


### PR DESCRIPTION
See #25 

- Support cache for SAMLResponse and not confidential Onelogin data.
- Reuse the SAMLResponse from cache meanwhile not expired, when saml_cache enabled.
- Reuse the generated SAMLResponse meanwhile not expired on iterations of loop or interactive modes.