### PR TITLE
Add more options to the config file and add support for more friendly account lists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ __pycache_
 /venv3
 virtualenv
 onelogin.sdk.json
+accounts.yaml

--- a/README.md
+++ b/README.md
@@ -72,10 +72,10 @@ Is a json file named onelogin.sdk.json as follows
 	"client_secret": "",
 	"region": "",
 	"ip": "",
-  "app_id": "",
-  "subdomain": "",
-  "username": "",
-  "profile": ""
+	"app_id": "",
+	"subdomain": "",
+	"username": "",
+	"profile": ""
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,11 @@ Is a json file named onelogin.sdk.json as follows
 	"client_id": "",
 	"client_secret": "",
 	"region": "",
-	"ip": ""
+	"ip": "",
+  "app_id": "",
+  "subdomain": "",
+  "username": "",
+  "profile": ""
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ python setup.py install
 
 The python script uses a settings file, where [OneLogin SDK properties](https://github.com/onelogin/onelogin-python-sdk#getting-started) are placed.
 
-Is a json file named onelogin.sdk.json as follows
+Is a json file named onelogin.sdk.json as follows:
+
 ```json
 {
 	"client_id": "",
@@ -85,12 +86,26 @@ Where:
  * client_secret  Onelogin OAuth2 client secret
  * region  Indicates where the instance is hosted. Possible values: 'us' or 'eu'.
  * ip  Indicates the IP to be used on the method to retrieve the SAMLResponse in order to bypass MFA if that IP was previously whitelisted.
+ * app_id Onelogin AWS integration app id
+ * subdomain Needs to be set to the correct subdomain for your AWS integration
+ * username The email address that is used to authenticate against Onelogin
+ * profile The AWS profile to use in ~/.aws/credentials
 
 For security reasons, IP only can be provided at the onelogin.sdk.json.
 On a shared machines where multiple users has access, That file should only be readable by the root of the machine that also controls the
 client_id / client_secret, and not by an end user, to prevent him manipulate the IP value.
 
 Place that file in the same path where the python script is invoked.
+
+There is an optional file that can be created to give more human readable names to the account list, named accounts.yaml, which should be placed in the same path where the python script is invoked:
+
+```yaml
+accounts:
+  "987654321012": Prod account
+  "123456789012": Dev Account
+```
+
+This isn't needed for the script to function but it provides a better user experience.
 
 ### Docker installation method
 

--- a/accounts.yaml.template
+++ b/accounts.yaml.template
@@ -1,0 +1,13 @@
+#
+# AWS Accounts
+#
+# Account number and account alias as desired
+# This will be used (if present) to display a friendly alias for your account in the account pick list
+# This should contain "accountnum: friendly name" as shown below and then renamed to "accounts.yaml" and
+# placed in the /src/aws_assume_role package directory BEFORE installation.
+#
+# If the file is not present the tool will run normally but wil, not display friendly aws account names
+#
+#accounts:
+#  "987654321012": Prod account
+#  "123456789012": Dev Account

--- a/accounts.yaml.template
+++ b/accounts.yaml.template
@@ -6,7 +6,7 @@
 # This should contain "accountnum: friendly name" as shown below and then renamed to "accounts.yaml" and
 # placed in the /src/aws_assume_role package directory BEFORE installation.
 #
-# If the file is not present the tool will run normally but wil, not display friendly aws account names
+# If the file is not present the tool will run normally but will, not display friendly aws account names
 #
 #accounts:
 #  "987654321012": Prod account

--- a/accounts.yaml.template
+++ b/accounts.yaml.template
@@ -4,7 +4,7 @@
 # Account number and account alias as desired
 # This will be used (if present) to display a friendly alias for your account in the account pick list
 # This should contain "accountnum: friendly name" as shown below and then renamed to "accounts.yaml" and
-# placed in the /src/aws_assume_role package directory BEFORE installation.
+# placed in the top most package directory BEFORE installation.
 #
 # If the file is not present the tool will run normally but will, not display friendly aws account names
 #

--- a/onelogin.sdk.json.template
+++ b/onelogin.sdk.json.template
@@ -2,5 +2,9 @@
 	"client_id": "",
 	"client_secret": "",
 	"region": "",
-	"ip": ""
+	"ip": "",
+  "app_id": "",
+  "subdomain": "",
+  "username": "",
+  "profile": ""
 }

--- a/onelogin.sdk.json.template
+++ b/onelogin.sdk.json.template
@@ -1,8 +1,8 @@
 {
-	"client_id": "",
-	"client_secret": "",
-	"region": "",
-	"ip": "",
+  "client_id": "",
+  "client_secret": "",
+  "region": "",
+  "ip": "",
   "app_id": "",
   "subdomain": "",
   "username": "",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+####### requirements.txt #######
+boto3
+onelogin
+pyyaml

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+
 #! /usr/bin/env python
 # -*- coding: utf-8 -*-
 
@@ -33,9 +34,11 @@ setup(
     package_dir={
         '': 'src',
     },
+    package_data={'': ['accounts.yaml','onelogin.sdk.json']},
     install_requires=[
         'boto3==1.7.84',
-        'onelogin==1.5.0'
+        'onelogin==1.5.0',
+        'pyyaml==5.1.2',
     ],
     entry_points={
         'console_scripts': ['onelogin-aws-assume-role=aws_assume_role.aws_assume_role:main']

--- a/src/aws_assume_role/accounts.py
+++ b/src/aws_assume_role/accounts.py
@@ -1,0 +1,43 @@
+#
+# Display Account Aliases
+#
+# Handles displaying a 'pretty' AWS account alias based on yaml config file provided by the user
+# Currently the onelogin saml does not support pulling the acct alias dynamically with the role names
+
+import yaml
+import os
+
+def identify_known_accounts(data):
+    """
+    Given a known list of account IDs from yaml config, append note about their account if they're known to us.
+    :return: Account description
+    """
+    # If the accounts custom aliases yaml file does not exist just default to normal behavior
+    try:
+        if os.path.isfile('accounts.yaml'):
+            accountsfile = open('onelogin.sdk.json').read()
+            contents = yaml.load(accountsfile, Loader=yaml.FullLoader)
+            accounts = contents["accounts"]
+            for acct in accounts.keys():
+                if acct in data:
+                    return accounts[acct]
+            return "Unidentified"
+
+    except FileNotFoundError:
+        return ""
+    except yaml.YAMLError:
+        print("ERROR: Your YAML configuration for the 'accounts.yaml' seems to be formatted incorrectly. \
+                             Please double check.  Defaulting to not display account aliases.")
+        return ""
+
+
+def pretty_choices(index, role_name, account_id):
+    """
+    Formats the output of the account option
+    :return: formatted print
+    """
+    account_alias = identify_known_accounts(account_id)
+    if account_alias:
+        print(f" {index} | {account_alias} - {role_name} (Account: {account_id})")
+    else:
+        print(" %s | %s (Account %s)" % (index, role_name, account_id))

--- a/src/aws_assume_role/accounts.py
+++ b/src/aws_assume_role/accounts.py
@@ -13,23 +13,17 @@ def identify_known_accounts(data):
     :return: Account description
     """
     # If the accounts custom aliases yaml file does not exist just default to normal behavior
-    try:
-        if os.path.isfile('accounts.yaml'):
-            accountsfile = open('onelogin.sdk.json').read()
-            contents = yaml.load(accountsfile, Loader=yaml.FullLoader)
+    if os.path.isfile('accounts.yaml'):
+        accountsfile = open('accounts.yaml').read()
+        contents = yaml.load(accountsfile, Loader=yaml.FullLoader)
+        if 'accounts' in contents.keys():
             accounts = contents["accounts"]
             for acct in accounts.keys():
                 if acct in data:
                     return accounts[acct]
-            return "Unidentified"
-
-    except FileNotFoundError:
+        return "Unidentified"
+    else:
         return ""
-    except yaml.YAMLError:
-        print("ERROR: Your YAML configuration for the 'accounts.yaml' seems to be formatted incorrectly. \
-                             Please double check.  Defaulting to not display account aliases.")
-        return ""
-
 
 def pretty_choices(index, role_name, account_id):
     """

--- a/src/aws_assume_role/aws_assume_role.py
+++ b/src/aws_assume_role/aws_assume_role.py
@@ -19,6 +19,8 @@ try:
 except ImportError:
     from writer import ConfigFileWriter
 
+# accounts aliases
+from .accounts import pretty_choices
 
 MFA_ATTEMPS_FOR_WARNING = 3
 TIME_SLEEP_ON_RESPONSE_PENDING = 15
@@ -468,7 +470,9 @@ def main():
                         role_info = role.split(",")[0].split(":")
                         account_id = role_info[4]
                         role_name = role_info[5].replace("role/", "")
-                        print(" %s | %s (Account %s)" % (index, role_name, account_id))
+
+                        pretty_choices(index, role_name, account_id)
+
                         if account_id in roles_by_app:
                             roles_by_app[account_id].append((index, role_name))
                         else:

--- a/src/aws_assume_role/aws_assume_role.py
+++ b/src/aws_assume_role/aws_assume_role.py
@@ -110,7 +110,7 @@ def get_options():
     if 'username' in config.keys():
         options.username = config['username']
     if 'profile' in config.keys():
-        options.profile = config['profile']
+        options.profile_name = config['profile']
 
     return options
 


### PR DESCRIPTION
This change allows for the addition of:

 * app_id
 * subdomain
 * username
 * profile

to the onelogin.sdk.json file purely as a convenience to provide default values.

Additionally an optional accounts.yaml file can be added with a map of account ids and names to provide a better user experience.

Includes changes made by github users Brian Provenzano (https://github.com/brian-provenzano) and Sean Rackley (https://github.com/seanrackley).