### PR TITLE
Fixing use of options.profile in get_options

### DIFF
--- a/src/aws_assume_role/aws_assume_role.py
+++ b/src/aws_assume_role/aws_assume_role.py
@@ -99,7 +99,7 @@ def get_options():
             options.subdomain = config['subdomain']
         if 'username' in config.keys() and config['username'] and not options.username:
             options.username = config['username']
-        if 'profile' in config.keys() and config['profile'] and not options.profile:
+        if 'profile' in config.keys() and config['profile'] and not options.profile_name:
             options.profile_name = config['profile']
         if 'duration' in config.keys() and config['duration'] and not options.duration:
             options.duration = config['duration']


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
**Version Installed:** onelogin-aws-assume-role 1.6.1

The CLI arg parser is using `profile_name` instead of `profile`.  So calling`options.profile` raises an exception.

## Related PRs
None

## Todos
- [ ] Tests
- [ ] Documentation


## Deploy Notes
N/A

## Steps to Test or Reproduce
This can be reproduced on master

1. Create a valid onelogin.aws.json
1. Create a vvalid onelogin.sdk.json
1. Run tool
1. `AttributeError` Exception is thrown

### Exception

```
python src/aws_assume_role/aws_assume_role.py

OneLogin AWS Assume Role Tool

Traceback (most recent call last):
  File "src/aws_assume_role/aws_assume_role.py", line 647, in <module>
    main()
  File "src/aws_assume_role/aws_assume_role.py", line 388, in main
    options = get_options()
  File "src/aws_assume_role/aws_assume_role.py", line 102, in get_options
    if 'profile' in config.keys() and config['profile'] and not options.profile:
AttributeError: 'Namespace' object has no attribute 'profile'
```

### onelogin.aws.json

```
{
  "app_id": 123456,
  "subdomain": "xxxx",
  "username": "xxx.xxx@xxx.com",
  "profile": "onelogin-mfa",
  "duration": 43199,
  "aws_region": "us-east-2"
}
```

### onelogin.sdk.json

```json
{
  "client_id": "xxx",
  "client_secret": "xxx",
  "region": "us",
  "ip": ""
}
```

## Impacted Areas in Application
List general components of the application that this PR will affect:

* This actually impacts all functionality because this code path is always traversed before any operation.