### PR TITLE
Documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ python setup.py install
 
 The python script uses a settings file, where [OneLogin SDK properties](https://github.com/onelogin/onelogin-python-sdk#getting-started) are placed.
 
-Is a json file named onelogin.sdk.json as follows:
+Is a json file named `onelogin.sdk.json` as follows:
 
 ```json
 {
@@ -85,14 +85,14 @@ Where:
  * region  Indicates where the instance is hosted. Possible values: 'us' or 'eu'.
  * ip  Indicates the IP to be used on the method to retrieve the SAMLResponse in order to bypass MFA if that IP was previously whitelisted.
 
-For security reasons, IP only can be provided at the onelogin.sdk.json.
+For security reasons, IP only can be provided in `onelogin.sdk.json`.
 On a shared machine where multiple users has access, That file should only be readable by the root of the machine that also controls the
 client_id / client_secret, and not by an end user, to prevent him manipulate the IP value.
 
 Place the file in the same path where the python script is invoked.
 
 
-There is an optional file onelogin.aws.json, that can be used if you plan to execute the script with some fixed values and avoid providing it on the command line each time.
+There is an optional file `onelogin.aws.json`, that can be used if you plan to execute the script with some fixed values and avoid providing it on the command line each time.
 
 ```json
 {
@@ -121,7 +121,7 @@ Where:
 The values provided on the command line will have preference
 over the values defined on this file.
 
-In addition, there is another optional file that can be created to give more human readable names to the account list, named accounts.yaml, which should be placed in the same path where the python script is invoked:
+In addition, there is another optional file that can be created to give more human readable names to the account list, named `accounts.yaml`, which should be placed in the same path where the python script is invoked:
 
 ```yaml
 accounts:
@@ -208,7 +208,7 @@ to install dependencies.
 
 ### Usage
 
-Assuming you have your AWS Multi Account app set up correctly and you’re using valid OneLogin API credentials stored on the onelogin.sdk.json placed at the root of the repository, using this tool is as simple as following the prompts.
+Assuming you have your AWS Multi Account app set up correctly and you’re using valid OneLogin API credentials stored on the `onelogin.sdk.json` placed at the root of the repository, using this tool is as simple as following the prompts.
 
 ```sh
 > onelogin-aws-assume-role

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ There is an optional file onelogin.aws.json, that can be used if you plan to exe
   "subdomain": "",
   "username": "",
   "profile": "",
-  "duration": "",
+  "duration": 3600,
   "aws_region": "",
   "aws_account_id": "",
   "aws_role_name": ""
@@ -113,7 +113,7 @@ Where:
  * subdomain Needs to be set to the correct subdomain for your AWS integration
  * username The email address that is used to authenticate against Onelogin
  * profile The AWS profile to use in ~/.aws/credentials
- * duration Desired AWS Credential Duration
+ * duration Desired AWS Credential Duration in seconds. Default: 3600, Min: 900, Max: 43200
  * aws_region AWS region to use
  * aws_account_id AWS account id to be used
  * aws_role_name AWS role name to select

--- a/onelogin.aws.json.template
+++ b/onelogin.aws.json.template
@@ -3,7 +3,7 @@
   "subdomain": "",
   "username": "",
   "profile": "",
-  "duration": "",
+  "duration": 3600,
   "aws_region": "",
   "aws_account_id": "",
   "aws_role_name": ""


### PR DESCRIPTION
This PR contains a couple minor documentation updates. 

1. In relation to the configuration parameter `duration`

- Set sample JSON for `duration` field in `onelogin.aws.json` to reflect that this is an integer field (rather than a string as is indicated currently).
- Add details to explicitly document that `duration` is in seconds and document min/max/default in `README.md`.

2. Adds syntax highlighting for filenames in `README.md`