### PR TITLE
Auto-select role if only AWS Account Id is specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ You can also make it regenerate and update the credentials file by using the `--
 
 You can also make it interactive, with the `-x` or `--interactive`option, and at the end of the iteration, you will be asked if want to generate new credentials for a new user or a new role.
 
-The selection of the AWS account and Role can be also be done with the --aws-account-id and --aws-role-name parameters.
+The selection of the AWS account and Role can be also be done with the `--aws-account-id` and `--aws-role-name` parameters. If both parameters are set then both will be matched against the list of available accounts and roles. If only `--aws-account-id` is specified and you only have one available role in that account, then that role will be chosen by default. If you have more than one role in the given account then you will need to select the appropriate one as per normal.
 
 If you plan to execute the script several times over different Accounts/Roles of the user and you want to cache the SAMLResponse, set the --cache-saml option
 

--- a/src/aws_assume_role/aws_assume_role.py
+++ b/src/aws_assume_role/aws_assume_role.py
@@ -132,8 +132,6 @@ def get_options():
     elif options.duration > 43200:
         options.duration = 43200
 
-    if options.aws_role_name is None and options.aws_account_id or options.aws_role_name and options.aws_account_id is None:
-        parser.error("--aws-account-id and --aws-role-name need to be set together")
     return options
 
 
@@ -636,6 +634,8 @@ def main():
                     role_option = None
                     if options.aws_account_id and options.aws_role_name and options.aws_account_id in roles_by_app:
                         role_option = next((index for index, role_name in roles_by_app[options.aws_account_id] if role_name == options.aws_role_name), None)
+                    elif options.aws_account_id and options.aws_role_name is None and len(roles_by_app[options.aws_account_id]) == 1:
+                        role_option = next((index for index, role_name in roles_by_app[options.aws_account_id]), None)
 
                     if role_option is None:
                         if options.aws_account_id and options.aws_role_name:


### PR DESCRIPTION
This PR removes the requirement for both AWS Account Id and AWS Role Name to be specified. With this change in place, only the account id needs to be specified and the role will be selected automatically provided that the user only has access to single role in the given account.