### PR TITLE
Add profiles element to onelogin.aws.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,16 @@ There is an optional file onelogin.aws.json, that can be used if you plan to exe
   "duration": "",
   "aws_region": "",
   "aws_account_id": "",
-  "aws_role_name": ""
+  "aws_role_name": "",
+  "profiles": {
+    "profile-1": {
+      "aws_account_id": "",
+      "aws_role_name": ""
+    },
+    "profile-2": {
+      "aws_account_id": ""
+    }
+  }
 }
 ```
 
@@ -117,6 +126,7 @@ Where:
  * aws_region AWS region to use
  * aws_account_id AWS account id to be used
  * aws_role_name AWS role name to select
+ * profiles Contains a list of profile->account id, and optionally role name mappings. If this attribute is populated `aws_account_id` and `aws_role_name` will be set based on the `profile` provided when running the script.
 
 The values provided on the command line will have preference
 over the values defined on this file.

--- a/onelogin.aws.json.template
+++ b/onelogin.aws.json.template
@@ -6,5 +6,14 @@
   "duration": "",
   "aws_region": "",
   "aws_account_id": "",
-  "aws_role_name": ""
+  "aws_role_name": "",
+  "profiles": {
+    "profile-1": {
+      "aws_account_id": "",
+      "aws_role_name": ""
+    },
+    "profile-2": {
+      "aws_account_id": ""
+    }
+  }
 }

--- a/src/aws_assume_role/aws_assume_role.py
+++ b/src/aws_assume_role/aws_assume_role.py
@@ -118,6 +118,12 @@ def get_options():
             options.aws_account_id = config['aws_account_id']
         if 'aws_role_name' in config.keys() and config['aws_role_name'] and not options.aws_role_name:
             options.aws_role_name = config['aws_role_name']
+        if 'profiles' in config.keys() and config['profiles'] and options.profile_name and options.profile_name in config['profiles'].keys():
+            profile = config['profiles'][options.profile_name]
+            if 'aws_account_id' in profile.keys() and profile['aws_account_id'] and not options.aws_account_id:
+                options.aws_account_id = profile['aws_account_id']
+            if 'aws_role_name' in profile.keys() and profile['aws_role_name'] and not options.aws_role_name:
+                options.aws_role_name = profile['aws_role_name']
 
     options.time = options.time
     if options.time < 15:


### PR DESCRIPTION
Allow users to configure a list of profiles in `onelogin.aws.json` which provide the mapping between `profile_name` and AWS account id/role name. This allows users to pre-configure a set of profiles and subsequently run the application with only the `--profile` argument supplied.