### PR TITLE
Add profiles to onelogin.aws.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,17 @@ There is an optional file onelogin.aws.json, that can be used if you plan to exe
   "duration": "",
   "aws_region": "",
   "aws_account_id": "",
-  "aws_role_name": ""
+  "aws_role_name": "",
+  "profiles": {
+    "profile-1": {
+      "aws_account_id": "",
+      "aws_role_name": "",
+      "aws_region": ""
+    },
+    "profile-2": {
+      "aws_account_id": ""
+    }
+  }
 }
 ```
 
@@ -117,11 +127,26 @@ Where:
  * aws_region AWS region to use
  * aws_account_id AWS account id to be used
  * aws_role_name AWS role name to select
+ * profiles Contains a list of profile->account id, and optionally role name mappings. If this attribute is populated `aws_account_id`, `aws_role_name` and `aws_region` will be set based on the `profile` provided when running the script.
 
-The values provided on the command line will have preference
-over the values defined on this file.
+**Note**: The values provided on the command line will take precedence over the values defined on this file and, values defined at the _global_ scope in the file, will take precedence over values defined at the `profiles` level. IN addition, each attribute is treating individually, so be aware that this may lead to somewhat strange behaviour when overriding a subset of parameters, when others are defined at a _lower level_ and not overriden. For example, if you had a `onelogin.aws.json` config file as follows:
 
-In addition, there is another optional file that can be created to give more human readable names to the account list, named accounts.yaml, which should be placed in the same path where the python script is invoked:
+```json
+{
+  ...
+  "aws_region": "eu-east-1",
+  "profiles": {
+    "my-account": {
+      "aws_account_id": "11111111",
+      "aws_role_name": "Administrator"
+    }
+  }
+}
+````
+
+And, you you subsequently ran the application with the command line arguments `--profile my-account --aws-acccount-id 22222222` then the application would ultimately attempt to log in with the role `Administrator` on account `22222222`, with region set to `eu-east-1` and, if successful, save the credentials to profile `my-account`. 
+
+In addition, there is another optional file that can be created to give more human readable names to the account list, named `accounts.yaml`, which should be placed in the same path where the python script is invoked:
 
 ```yaml
 accounts:

--- a/onelogin.aws.json.template
+++ b/onelogin.aws.json.template
@@ -6,5 +6,15 @@
   "duration": "",
   "aws_region": "",
   "aws_account_id": "",
-  "aws_role_name": ""
+  "aws_role_name": "",
+  "profiles": {
+    "profile-1": {
+      "aws_account_id": "",
+      "aws_role_name": "",
+      "aws_region": ""
+    },
+    "profile-2": {
+      "aws_account_id": ""
+    }
+  }
 }

--- a/src/aws_assume_role/aws_assume_role.py
+++ b/src/aws_assume_role/aws_assume_role.py
@@ -118,6 +118,14 @@ def get_options():
             options.aws_account_id = config['aws_account_id']
         if 'aws_role_name' in config.keys() and config['aws_role_name'] and not options.aws_role_name:
             options.aws_role_name = config['aws_role_name']
+        if 'profiles' in config.keys() and config['profiles'] and options.profile_name and options.profile_name in config['profiles'].keys():
+            profile = config['profiles'][options.profile_name]
+            if 'aws_account_id' in profile.keys() and profile['aws_account_id'] and not options.aws_account_id:
+                options.aws_account_id = profile['aws_account_id']
+            if 'aws_role_name' in profile.keys() and profile['aws_role_name'] and not options.aws_role_name:
+                options.aws_role_name = profile['aws_role_name']
+            if 'aws_region' in profile.keys() and profile['aws_region'] and not options.aws_region:
+                options.aws_region = profile['aws_region']
 
     options.time = options.time
     if options.time < 15:


### PR DESCRIPTION
Allows user to define a set of profiles linked to an account id, role and region so that they don't need to specify this every time the app is run; it is sufficient to just supply the desired profile