### PR TITLE
Use files from default aws directory if available

### DIFF
--- a/src/aws_assume_role/aws_assume_role.py
+++ b/src/aws_assume_role/aws_assume_role.py
@@ -149,13 +149,14 @@ def get_options():
 
 
 def get_config():
-    json_data = None
     onelogin_aws_filename = "onelogin.aws.json"
     if os.path.isfile(onelogin_aws_filename):
         json_data = open(onelogin_aws_filename).read()
+    	return json.loads(json_data)
     elif os.path.isfile(os.path.expanduser("~/.aws/%s" % onelogin_aws_filename)):
         json_data = open(os.path.expanduser("~/.aws/%s" % onelogin_aws_filename)).read()
-    return json.loads(json_data)
+    	return json.loads(json_data)
+    return None
 
 
 def get_client(options):

--- a/src/aws_assume_role/aws_assume_role.py
+++ b/src/aws_assume_role/aws_assume_role.py
@@ -163,8 +163,13 @@ def get_client(options):
         client_secret = options.client_secret
         region = options.region
     else:
-        if os.path.isfile('onelogin.sdk.json'):
-            json_data = open('onelogin.sdk.json').read()
+        json_data = None
+        onelogin_sdk_filename = "onelogin.sdk.json"
+        if os.path.isfile(onelogin_sdk_filename):
+            json_data = open(onelogin_sdk_filename).read()
+        elif os.path.isfile(os.path.expanduser("~/.aws/%s" % onelogin_sdk_filename)):
+            json_data = open(os.path.expanduser("~/.aws/%s" % onelogin_sdk_filename)).read()
+        if json_data:
             data = json.loads(json_data)
             if 'client_id' in data.keys() and 'client_secret' in data.keys():
                 client_id = data['client_id']

--- a/src/aws_assume_role/aws_assume_role.py
+++ b/src/aws_assume_role/aws_assume_role.py
@@ -149,13 +149,14 @@ def get_options():
 
 
 def get_config():
+    json_data = None
     onelogin_aws_filename = "onelogin.aws.json"
     if os.path.isfile(onelogin_aws_filename):
         json_data = open(onelogin_aws_filename).read()
-    	return json.loads(json_data)
     elif os.path.isfile(os.path.expanduser("~/.aws/%s" % onelogin_aws_filename)):
         json_data = open(os.path.expanduser("~/.aws/%s" % onelogin_aws_filename)).read()
-    	return json.loads(json_data)
+    if json_data:
+        return json.loads(json_data)
     return None
 
 

--- a/src/aws_assume_role/aws_assume_role.py
+++ b/src/aws_assume_role/aws_assume_role.py
@@ -149,9 +149,13 @@ def get_options():
 
 
 def get_config():
-    if os.path.isfile('onelogin.aws.json'):
-        json_data = open('onelogin.aws.json').read()
-        return json.loads(json_data)
+    json_data = None
+    onelogin_aws_filename = "onelogin.aws.json"
+    if os.path.isfile(onelogin_aws_filename):
+        json_data = open(onelogin_aws_filename).read()
+    elif os.path.isfile(os.path.expanduser("~/.aws/%s" % onelogin_aws_filename)):
+        json_data = open(os.path.expanduser("~/.aws/%s" % onelogin_aws_filename)).read()
+    return json.loads(json_data)
 
 
 def get_client(options):


### PR DESCRIPTION
This PR makes the tool check for the existence of the config files in the default `.aws` directory as well. If a file exists in the current directory, that will win.