### PR TITLE
Feature/support specifying path to config

### DIFF
--- a/src/aws_assume_role/aws-assume-role.py
+++ b/src/aws_assume_role/aws-assume-role.py
@@ -1,1 +1,0 @@
-aws_assume_role.py

--- a/src/aws_assume_role/aws_assume_role.py
+++ b/src/aws_assume_role/aws_assume_role.py
@@ -83,7 +83,7 @@ def get_options():
                         help="Be asked how procced in each iteration?")
     parser.add_argument("-c", "--config-file",
                         dest="config_file",
-                        help="AWS role name to select")
+                        help="Path to config file (onelogin.aws.json)")
     parser.add_argument("--aws-region",
                         dest="aws_region",
                         help="AWS region to use")

--- a/src/aws_assume_role/aws_assume_role.py
+++ b/src/aws_assume_role/aws_assume_role.py
@@ -81,6 +81,9 @@ def get_options():
                         default=False,
                         action="store_true",
                         help="Be asked how procced in each iteration?")
+    parser.add_argument("-c", "--config-file",
+                        dest="config_file",
+                        help="AWS role name to select")
     parser.add_argument("--aws-region",
                         dest="aws_region",
                         help="AWS region to use")
@@ -100,7 +103,7 @@ def get_options():
 
     # Read params from file, but only use them
     # if no value provided on command line
-    config = get_config()
+    config = get_config(options.config_file)
     if config is not None:
         if 'app_id' in config.keys() and config['app_id'] and not options.app_id:
             options.app_id = config['app_id']
@@ -143,9 +146,10 @@ def get_options():
     return options
 
 
-def get_config():
-    if os.path.isfile('onelogin.aws.json'):
-        json_data = open('onelogin.aws.json').read()
+def get_config(config_file_path):
+    path_to_config = config_file_path if config_file_path is not None else 'onelogin.aws.json'
+    if os.path.isfile(path_to_config):
+        json_data = open(path_to_config).read()
         return json.loads(json_data)
 
 


### PR DESCRIPTION
We ran into a situation where we need to authenticate against a dev app and a prod app. A better solution would be to refactor the `onelogin.aws.json` config file structure, but a much simpler option would be to support passing different config files. This PR implements the latter.