### PR TITLE
Fix a number of issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ####### requirements.txt #######
 boto3
-onelogin
+onelogin>=2.0
 pyyaml
 lxml

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     package_data={'': ['accounts.yaml','onelogin.sdk.json']},
     install_requires=[
         'boto3>=1.7.84',
-        'onelogin>=1.9.0',
+        'onelogin>=2.0.3',
         'pyyaml>=5.1.2',
         'lxml'
     ],

--- a/src/aws_assume_role/aws_assume_role.py
+++ b/src/aws_assume_role/aws_assume_role.py
@@ -254,6 +254,8 @@ def get_saml_response(client, username_or_email, password, app_id, onelogin_subd
                     username_or_email = sys.stdin.readline().strip()
                 else:
                     raise Exception(error_msg)
+            elif client.error is not None:
+                print("Error %s. %s" % (client.error, client.error_description))
 
         if saml_endpoint_response and saml_endpoint_response.type == "pending":
             time.sleep(TIME_SLEEP_ON_RESPONSE_PENDING)

--- a/src/aws_assume_role/version.py
+++ b/src/aws_assume_role/version.py
@@ -1,3 +1,3 @@
 #! /usr/bin/env python
 
-__version__ = '1.9.0'
+__version__ = '1.10.0'


### PR DESCRIPTION
- Update to latest OneLogin Python SDK and pin it to version 2
- Allow using the OneLogin SAML2 APIs so that IP white listing can take effect (--saml-api-version to set between version 1 and 2)
- Allow setting the IP address used for the SAML assertion via argument (--ip to set the value)
