### PR TITLE
Hard code the specific onelogin version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ####### requirements.txt #######
 boto3
-onelogin>=2.0
+onelogin==2.0.3
 pyyaml
 lxml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ####### requirements.txt #######
 boto3
-onelogin==2.0.3
+onelogin==2.0.4
 pyyaml
 lxml


### PR DESCRIPTION
This needs to be in 2.0.3 until we can convert this to 3.0.0.

When I don't do this, it still tries to install 3.0.0.

See https://github.com/onelogin/onelogin-python-aws-assume-role/issues/76