### PR TITLE
Pin onelogin-python-sdk version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     package_data={'': ['accounts.yaml','onelogin.sdk.json']},
     install_requires=[
         'boto3>=1.7.84',
-        'onelogin>=2.0.3',
+        'onelogin==2.0.4',
         'pyyaml>=5.1.2',
         'lxml'
     ],

--- a/src/aws_assume_role/version.py
+++ b/src/aws_assume_role/version.py
@@ -1,3 +1,3 @@
 #! /usr/bin/env python
 
-__version__ = '1.10.0'
+__version__ = '1.10.1'


### PR DESCRIPTION
Version 3.0.0 has breaking changes, so pin to version 2.0.4 for now.