### PR TITLE
Add OSX Keychain integration to the command-line and config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,9 +194,9 @@ Flag `--onelogin-password` is meant for integration with a password manager, lik
 - OSX Keychain: `--onelogin-password $(security find-generic-password -a $USER -s onelogin -w)`
 - 1Password CLI: `--onelogin-password $(op item get "onelogin" --fields label=password)`
 
-To read the onelogin username and password directly from OSX Keychain without using the integation above, on the command-line use `--keychain-account` and/or `--keychain-service`. (In `onelogin.aws.json` those are `keychain_account` and `keychain_service`.)
-- If you specify only the keychain account, it will use "onelogin" as the keychain service.
-- If you specify only the keychain service, then keychain account will default to `onelogin_username` minus the "@" symbol and everything following it.
+To read the onelogin username and password directly from OSX Keychain without using the integation above, on the command-line use `--keychain-account` and/or `--keychain-service`. You can skip the command-line arguments entirely by putting those in `onelogin.aws.json` as `keychain_account` and `keychain_service`, respectively.
+- If you specify only the keychain account on the command-line or in `onelogin.aws.json`, it will use "onelogin" as the keychain service.
+- If you specify only the keychain service, then "keychain account" will default to "onelogin username", minus the "@" symbol and everything that follows it.
 
 **NOTE:** *Technically you can specify your password after `--onelogin-password`, but it's bad practice - because that gets saved in your command history and it's visible in your process list.*  **Don't do it.**
 

--- a/README.md
+++ b/README.md
@@ -190,12 +190,15 @@ OTP Code (`--otp`)
 and the cli will use this otp only for the first interaction
 requiring a manual OTP Code
 
-_Note: Specifying your password directly with `--onelogin-password` is bad practice,
-you should use that flag together with password managers, eg. with the OSX Keychain:
-`--onelogin-password $(security find-generic-password -a $USER -s onelogin -w)`,
-so your password won't be saved in you command line history.
-Please note that your password **will** be visible in your process list,
-if you use this flag (as the expanded command line arguments are part of the name of the process)._
+Flag `--onelogin-password` is meant for integration with a password manager, like OSX Keychain, 1Password, KeePass, LastPass, etc.  e.g.:
+- OSX Keychain: `--onelogin-password $(security find-generic-password -a $USER -s onelogin -w)`
+- 1Password CLI: `--onelogin-password $(op item get "onelogin" --fields label=password)`
+
+To read the onelogin username and password directly from OSX Keychain without using the integation above, on the command-line use `--keychain-account` and/or `--keychain-service`. (In `onelogin.aws.json` those are `keychain_account` and `keychain_service`.)
+- If you specify only the keychain account, it will use "onelogin" as the keychain service.
+- If you specify only the keychain service, then keychain account will default to `onelogin_username` minus the "@" symbol and everything following it.
+
+**NOTE:** *Technically you can specify your password after `--onelogin-password`, but it's bad practice - because that gets saved in your command history and it's visible in your process list.*  **Don't do it.**
 
 With that data, a SAMLResponse is retrieved. And possible AWS Role are retrieved.
 

--- a/README.md
+++ b/README.md
@@ -190,15 +190,15 @@ OTP Code (`--otp`)
 and the cli will use this otp only for the first interaction
 requiring a manual OTP Code
 
-Flag `--onelogin-password` is meant for integration with a password manager, like OSX Keychain, 1Password, KeePass, LastPass, etc.  e.g.:
+Flag `--onelogin-password` is meant for integration with a password manager, like OSX Keychain, 1Password, KeePass, LastPass, etc. e.g.:
 - OSX Keychain: `--onelogin-password $(security find-generic-password -a $USER -s onelogin -w)`
 - 1Password CLI: `--onelogin-password $(op item get "onelogin" --fields label=password)`
 
-To read the onelogin username and password directly from OSX Keychain without using the integation above, on the command-line use `--keychain-account` and/or `--keychain-service`. You can skip the command-line arguments entirely by putting those in `onelogin.aws.json` as `keychain_account` and `keychain_service`, respectively.
-- If you specify only the keychain account on the command-line or in `onelogin.aws.json`, it will use "onelogin" as the keychain service.
-- If you specify only the keychain service, then "keychain account" will default to "onelogin username", minus the "@" symbol and everything that follows it.
+However, using any of these leaves your password visible in the process table because command-line arguments are expanded before applications are started.  Mac users can avoid that by reading the password directly from OSX Keychain with arguments `--keychain-account` and/or `--keychain-service`.  Skip the command-line arguments entirely by putting those in `onelogin.aws.json` as `keychain_account` and `keychain_service`, respectively.
+- If you specify only the keychain account on the command-line or in `onelogin.aws.json`, it will default to "onelogin" as the keychain service.
+- If you specify only the keychain service, then "keychain account" will use "onelogin username", minus the "@" symbol and everything that follows it.
 
-**NOTE:** *Technically you can specify your password after `--onelogin-password`, but it's bad practice - because that gets saved in your command history and it's visible in your process list.*  **Don't do it.**
+**NOTE:** *Technically you can specify your password after `--onelogin-password`, but it's bad practice - because that's visible in the machine's process list and, worse, it gets saved in your command history.*  **Don't do it.**
 
 With that data, a SAMLResponse is retrieved. And possible AWS Role are retrieved.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ boto3>=1.7.84
 onelogin==2.0.4
 pyyaml>=5.1.2
 lxml
+keychain>=23.0.0

--- a/src/aws_assume_role/aws_assume_role.py
+++ b/src/aws_assume_role/aws_assume_role.py
@@ -654,7 +654,6 @@ def main():
             if password is None:
                 if options.password:
                     password = options.password
-                    print("Password found in config file or command line")
                 else:
                     if options.keychain_service:
                         password = keyring.get_password(options.keychain_service, options.keychain_account)

--- a/src/aws_assume_role/aws_assume_role.py
+++ b/src/aws_assume_role/aws_assume_role.py
@@ -657,7 +657,7 @@ def main():
                     print("Password found in config file or command line")
                 else:
                     if options.keychain_service:
-                        password = keyring.get_password(options.keychain_service,options.keychain_account)
+                        password = keyring.get_password(options.keychain_service, options.keychain_account)
                         if password is not None:
                             print("Password found in keychain")
                         else:

--- a/src/aws_assume_role/aws_assume_role.py
+++ b/src/aws_assume_role/aws_assume_role.py
@@ -260,7 +260,7 @@ def get_saml_response(client, username_or_email, password, app_id, onelogin_subd
                 elif client.error_description in ["Authentication Failed: Invalid user credentials",
                                                   "password is empty"]:
                     print(error_msg)
-                    password = getpass.getpass("\nOneLogin Password1: ")
+                    password = getpass.getpass("\nOneLogin Password: ")
                 elif client.error_description == "username is empty":
                     print(error_msg)
                     print("OneLogin Username: ")

--- a/src/aws_assume_role/aws_assume_role.py
+++ b/src/aws_assume_role/aws_assume_role.py
@@ -663,7 +663,7 @@ def main():
                         else:
                             print("Unable to find password in OSX keychain for account / service -> ", options.keychain_account, "/", options.keychain_service)
                 if password is None:
-                    password = getpass.getpass("\nOneLogin Password3: ")
+                    password = getpass.getpass("\nOneLogin Password: ")
 
             if app_id is None:
                 if options.app_id:

--- a/src/aws_assume_role/aws_assume_role.py
+++ b/src/aws_assume_role/aws_assume_role.py
@@ -658,7 +658,7 @@ def main():
                     if options.keychain_service:
                         password = keyring.get_password(options.keychain_service, options.keychain_account)
                         if password is not None:
-                            print("Password found in keychain")
+                            pass
                         else:
                             print("Unable to find password in OSX keychain for account / service -> ", options.keychain_account, "/", options.keychain_service)
                 if password is None:

--- a/src/aws_assume_role/aws_assume_role.py
+++ b/src/aws_assume_role/aws_assume_role.py
@@ -639,7 +639,7 @@ def main():
             print("OneLogin Username: ")
             username_or_email = sys.stdin.readline().strip()
 
-            password = getpass.getpass("\nOneLogin Password2: ")
+            password = getpass.getpass("\nOneLogin Password: ")
             ask_for_user_again = False
             ask_for_role_again = True
         elif result is None and missing_onelogin_data:


### PR DESCRIPTION
This PR will allow Mac OSX Keychain users to pull their password directly from OSX Keychain without using "--onelogin-password".  There are 2 new command-line options (`--keychain-account`, `--keychain-service`) and 2 matching config file entries (`keychain_account`, `keychain_service`), all of which are explained in the updated README file. 