### PR TITLE
fix: prompt for AWS region when switching roles

### DIFF
--- a/src/aws_assume_role/aws_assume_role.py
+++ b/src/aws_assume_role/aws_assume_role.py
@@ -745,8 +745,8 @@ def main():
                 principal_arn = selected_role_data[1]
                 ask_for_user_again = False
 
-        if i == 0:
-            # AWS Region
+        if i == 0 or ask_for_role_again:
+            # AWS Region - prompt on first run or when switching roles
             if options.aws_region:
                 aws_region = options.aws_region
             else:
@@ -754,6 +754,7 @@ def main():
                 aws_region = sys.stdin.readline().strip()
             if not aws_region or aws_region == "-":
                 aws_region = default_aws_region
+            ask_for_role_again = False
 
         conn = boto3.client('sts', region_name=aws_region, config=botocore_config)
         try:


### PR DESCRIPTION
## Summary

When users switch to a different AWS account/role using interactive mode (`-x` flag), the AWS region was not being prompted for - it remained set to the value from the first iteration.

**Root cause:** The region prompt block was gated by `if i == 0:`, meaning it only executed on the first loop iteration. When `ask_for_role_again` was set to `True` (triggered by selecting a different role), the role selection ran again but the region prompt was skipped.

**Fix:** Added `ask_for_role_again` to the condition: `if i == 0 or ask_for_role_again:`, ensuring users are prompted for the region whenever they switch roles.

## Test Plan

1. Run the tool with `-x` (interactive mode) and multiple AWS roles available
2. Complete initial authentication and select a role/region
3. When prompted "Do you want to execute now the process for the same user but with other AWS Role?", answer "y"
4. Verify you are now prompted for AWS Region (previously this was skipped)
5. Select a different region and confirm credentials are generated for the new region

## Related

- Azure DevOps: [AB#647055](https://dev.azure.com/1id/a4c3e342-aef6-43ce-930a-fdf688dd1ed6/_workitems/edit/647055)
- Customer case: 02948625

🤖 Generated with [Claude Code](https://claude.com/claude-code)