### PR TITLE
Bump version to 2.0.0

### DIFF
--- a/src/aws_assume_role/version.py
+++ b/src/aws_assume_role/version.py
@@ -1,3 +1,3 @@
 #! /usr/bin/env python
 
-__version__ = '1.10.1'
+__version__ = '2.0.0'


### PR DESCRIPTION
## Summary

Version bump for the **v2.0.0** release.

This is a **major** bump because the changes merged in #94 are breaking for downstream consumers:
- The `onelogin` SDK dependency was **removed** in favour of a direct `requests`-based client.
- The supported **Python floor moved to 3.8** (dropped 2.7 / 3.5).

## Release steps (after merge)

1. Live end-to-end SAML smoke test against a real OneLogin↔AWS connector.
2. Publish a GitHub Release tagged `v2.0.0` → `publish.yml` builds and uploads to PyPI via Trusted Publishing.

[AB#698642](https://dev.azure.com/1id/a4c3e342-aef6-43ce-930a-fdf688dd1ed6/_workitems/edit/698642)