### PR TITLE
docs: pip/pipx install instructions + refresh dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,31 @@ The project is hosted at github. You can download it from:
 
 #### Pypi
 
-The toolkit is hosted in pypi, you can find the python-saml package at [https://pypi.python.org/pypi/onelogin-aws-assume-role](https://pypi.python.org/pypi/onelogin-aws-assume-role)
+The toolkit is hosted on pypi, you can find the package at [https://pypi.org/project/onelogin-aws-assume-role/](https://pypi.org/project/onelogin-aws-assume-role/)
+
+The quickest way to install the command-line tool is from PyPI:
+
+```
+pip install onelogin-aws-assume-role
+```
+
+To install it as an isolated command-line tool (recommended if you just want to
+use it rather than develop on it), use [pipx](https://pypa.github.io/pipx/):
+
+```
+pipx install onelogin-aws-assume-role
+```
+
+This avoids having to manage a virtualenv yourself; `pipx` keeps the tool and
+its dependencies isolated while still putting `onelogin-aws-assume-role` on your
+PATH.
 
 ### Dependencies
 
-It works with python2 and python3.
+Requires Python 3.8+.
 
 * boto3  AWS Python SDK
-* onelogin  OneLogin Python SDK
+* requests  HTTP client used to call the OneLogin API
 * pyyaml  YAML parser
 * lxml  XML and HTML processor
 


### PR DESCRIPTION
Addresses #5 (Homebrew/packaging friction) and brings the README in line with the v2.0.0 changes.

- Adds a `pip install onelogin-aws-assume-role` quickstart and a `pipx install` option so users don't have to clone the repo and manage a virtualenv just to run the CLI. `pipx` gives the same "isolated, no manual venv" benefit a brew formula would, without the maintenance overhead of a formula.
- Refreshes the stale **Dependencies** section: Python 3.8+ (was "python2 and python3") and `requests` instead of the removed `onelogin` SDK.

Fixes #5
[AB#698642](https://dev.azure.com/1id/a4c3e342-aef6-43ce-930a-fdf688dd1ed6/_workitems/edit/698642)