### PR TITLE
fix: declare keyring dependency (2.0.1) — 2.0.0 crashes on fresh install

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ boto3>=1.7.84
 requests>=2.20.0
 pyyaml>=5.1.2
 lxml
-keychain>=23.0.0
+keyring>=23.0.0

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,8 @@ setup(
         'boto3>=1.7.84',
         'requests>=2.20.0',
         'pyyaml>=5.1.2',
-        'lxml'
+        'lxml',
+        'keyring>=23.0.0'
     ],
     entry_points={
         'console_scripts': ['onelogin-aws-assume-role=aws_assume_role.aws_assume_role:main']

--- a/src/aws_assume_role/version.py
+++ b/src/aws_assume_role/version.py
@@ -1,3 +1,3 @@
 #! /usr/bin/env python
 
-__version__ = '2.0.0'
+__version__ = '2.0.1'

--- a/tests/test_cli_imports.py
+++ b/tests/test_cli_imports.py
@@ -1,0 +1,28 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Smoke test: the CLI module must import with only its declared dependencies.
+
+This guards against a runtime dependency being used in code but missing from
+`setup.py` / `requirements.txt` (e.g. `keyring`, which a fresh `pip install`
+must pull in or the console script crashes on startup).
+"""
+
+import sys
+import os
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+
+class CliImportTest(unittest.TestCase):
+    def test_cli_module_imports(self):
+        # Importing the entry-point module exercises every top-level import
+        # (keyring, boto3, lxml, yaml, requests, ...). If any declared
+        # dependency is missing, this raises ModuleNotFoundError.
+        from aws_assume_role import aws_assume_role
+        self.assertTrue(callable(aws_assume_role.main))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## ⚠️ Fixes a release-breaking bug in 2.0.0

A fresh `pip install onelogin-aws-assume-role==2.0.0` crashes immediately:

```
ModuleNotFoundError: No module named 'keyring'
```

The OSX-keychain feature added `import keyring` at module load, but `keyring` was never declared in `setup.py`, and `requirements.txt` listed `keychain` (an unrelated PyPI package). v1.10.1 predates the import, so 2.0.0 is the first release to expose it.

## Fix

- Add `keyring>=23.0.0` to `install_requires`.
- Correct `requirements.txt`: `keychain` → `keyring`.
- **Add a CLI import smoke test** (`tests/test_cli_imports.py`) that imports the entry-point module, so a runtime dependency missing from packaging fails CI. The existing tests only imported `onelogin_client`, which is why this slipped through.
- Bump version to **2.0.1**.

## Verification

In a clean venv: `pip install -e .` now pulls `keyring`; the full suite (25 tests) passes; and `onelogin-aws-assume-role --help` starts cleanly.

[AB#698642](https://dev.azure.com/1id/a4c3e342-aef6-43ce-930a-fdf688dd1ed6/_workitems/edit/698642)