### PR TITLE
feat: display the MFA label with the user selected name

### DIFF
--- a/src/aws_assume_role/aws_assume_role.py
+++ b/src/aws_assume_role/aws_assume_role.py
@@ -335,7 +335,7 @@ def get_saml_response(client, username_or_email, password, app_id, onelogin_subd
                 if mfa_verify_info is None:
                     print("-----------------------------------------------------------------------")
                     for index, device in enumerate(devices):
-                        label = device.auth_factor_name
+                        label = device.auth_factor_name or device.type
                         if device.display_name:
                             label += " (%s)" % device.display_name
                         print(" " + str(index) + " | " + label)

--- a/src/aws_assume_role/aws_assume_role.py
+++ b/src/aws_assume_role/aws_assume_role.py
@@ -313,6 +313,11 @@ def get_saml_response(client, username_or_email, password, app_id, onelogin_subd
             devices = mfa.devices
             state_token = mfa.state_token
 
+            if mfa.user and mfa.user.get('id'):
+                enriched = client.get_otp_devices(mfa.user['id'])
+                if enriched:
+                    devices = enriched
+
             if mfa_verify_info is None or 'device_id' not in mfa_verify_info:
                 print("\nMFA Required")
                 print("Authenticate using one of these devices:")
@@ -330,7 +335,10 @@ def get_saml_response(client, username_or_email, password, app_id, onelogin_subd
                 if mfa_verify_info is None:
                     print("-----------------------------------------------------------------------")
                     for index, device in enumerate(devices):
-                        print(" " + str(index) + " | " + device.type)
+                        label = device.auth_factor_name
+                        if device.display_name:
+                            label += " (%s)" % device.display_name
+                        print(" " + str(index) + " | " + label)
 
                     print("-----------------------------------------------------------------------")
 

--- a/src/aws_assume_role/onelogin_client.py
+++ b/src/aws_assume_role/onelogin_client.py
@@ -36,6 +36,7 @@ import requests
 TOKEN_REQUEST_URL = "https://%s.onelogin.com/auth/oauth2/v2/token"
 GET_SAML_ASSERTION_URL = "https://%s.onelogin.com/api/%s/saml_assertion"
 GET_SAML_VERIFY_FACTOR = "https://%s.onelogin.com/api/%s/saml_assertion/verify_factor"
+GET_OTP_DEVICES_URL = "https://%s.onelogin.com/api/%s/users/%s/otp_devices"
 
 # Versions supported by the SAML assertion endpoints; the last entry is the
 # default when the caller does not request a specific version.
@@ -45,7 +46,12 @@ SAML_ASSERTION_VERSIONS = [1, 2]
 class Device(object):
     def __init__(self, data):
         self.id = data.get('device_id', data.get('id'))
-        self.type = str(data.get('device_type', data.get('type', '')))
+        self.type = str(data.get('device_type', data.get('type_display_name', data.get('type', ''))))
+        self.display_name = data.get('user_display_name', '')
+        self.auth_factor_name = data.get('auth_factor_name', '')
+        self.default = data.get('default', False)
+        self.active = data.get('active', True)
+        self.needs_trigger = data.get('needs_trigger', False)
 
 
 class MFA(object):
@@ -259,3 +265,31 @@ class OneLoginClient(object):
         if otp_token:
             data['otp_token'] = otp_token
         return self._retrieve_saml_assertion(url, data, version_id)
+
+    # -- MFA Devices ------------------------------------------------------
+
+    def get_otp_devices(self, user_id):
+        """Fetch the full OTP device list for a user from the devices endpoint.
+
+        Returns a list of Device objects with richer metadata than the SAML
+        assertion response provides (display name, active status, etc.).
+        Returns an empty list on error, leaving self.error set.
+        """
+        self.clean_error()
+        version_id = self._assertion_version()
+        url = GET_OTP_DEVICES_URL % (self._get_subdomain(), version_id, user_id)
+        response = requests.get(url, headers=self.get_authorized_headers(),
+                                timeout=self.default_timeout)
+        if response.status_code == 200:
+            try:
+                content = response.json()
+            except ValueError:
+                return []
+            devices_data = content.get('data', {})
+            if isinstance(devices_data, dict):
+                otp_devices = devices_data.get('otp_devices', [])
+            else:
+                otp_devices = []
+            return [Device(d) for d in otp_devices if d.get('active', True)]
+        self.set_error(response)
+        return []

--- a/src/aws_assume_role/onelogin_client.py
+++ b/src/aws_assume_role/onelogin_client.py
@@ -36,7 +36,9 @@ import requests
 TOKEN_REQUEST_URL = "https://%s.onelogin.com/auth/oauth2/v2/token"
 GET_SAML_ASSERTION_URL = "https://%s.onelogin.com/api/%s/saml_assertion"
 GET_SAML_VERIFY_FACTOR = "https://%s.onelogin.com/api/%s/saml_assertion/verify_factor"
-GET_OTP_DEVICES_URL = "https://%s.onelogin.com/api/%s/users/%s/otp_devices"
+# The User Management API is versioned independently of the SAML Assertion
+# API, so this path hardcodes v1 rather than reusing the assertion version.
+GET_OTP_DEVICES_URL = "https://%s.onelogin.com/api/1/users/%s/otp_devices"
 
 # Versions supported by the SAML assertion endpoints; the last entry is the
 # default when the caller does not request a specific version.
@@ -276,8 +278,7 @@ class OneLoginClient(object):
         Returns an empty list on error, leaving self.error set.
         """
         self.clean_error()
-        version_id = self._assertion_version()
-        url = GET_OTP_DEVICES_URL % (self._get_subdomain(), version_id, user_id)
+        url = GET_OTP_DEVICES_URL % (self._get_subdomain(), user_id)
         response = requests.get(url, headers=self.get_authorized_headers(),
                                 timeout=self.default_timeout)
         if response.status_code == 200:

--- a/tests/test_onelogin_client.py
+++ b/tests/test_onelogin_client.py
@@ -127,6 +127,36 @@ class DeviceTest(unittest.TestCase):
         self.assertEqual(d.id, 7)
         self.assertEqual(d.type, 'OneLogin Protect')
 
+    def test_otp_devices_api_fields(self):
+        d = Device({
+            'id': 99,
+            'type_display_name': 'Duo Security',
+            'user_display_name': 'Work Duo',
+            'auth_factor_name': 'Duo',
+            'default': True,
+            'active': True,
+            'needs_trigger': False,
+        })
+        self.assertEqual(d.id, 99)
+        self.assertEqual(d.type, 'Duo Security')
+        self.assertEqual(d.display_name, 'Work Duo')
+        self.assertEqual(d.auth_factor_name, 'Duo')
+        self.assertTrue(d.default)
+        self.assertTrue(d.active)
+        self.assertFalse(d.needs_trigger)
+
+    def test_defaults_when_extended_fields_absent(self):
+        d = Device({'device_id': 1, 'device_type': 'OneLogin SMS'})
+        self.assertEqual(d.display_name, '')
+        self.assertEqual(d.auth_factor_name, '')
+        self.assertFalse(d.default)
+        self.assertTrue(d.active)
+        self.assertFalse(d.needs_trigger)
+
+    def test_type_prefers_device_type_over_type_display_name(self):
+        d = Device({'id': 1, 'device_type': 'GoogleAuth', 'type_display_name': 'Google Authenticator'})
+        self.assertEqual(d.type, 'GoogleAuth')
+
 
 class OneLoginClientHelpersTest(unittest.TestCase):
     def test_subdomain_from_region(self):
@@ -238,6 +268,107 @@ class RequestConstructionTest(unittest.TestCase):
             'app_id': 12345, 'device_id': '678', 'state_token': 'state-tok',
             'do_not_notify': True, 'otp_token': '999999',
         })
+
+
+class GetOtpDevicesTest(unittest.TestCase):
+    @mock.patch.object(onelogin_client.requests, 'get')
+    def test_returns_device_list_with_rich_fields(self, get):
+        get.return_value = _fake_response(200, {
+            'data': {
+                'otp_devices': [
+                    {
+                        'id': 1, 'type_display_name': 'Google Authenticator',
+                        'user_display_name': 'My Phone', 'auth_factor_name': 'Google Authenticator',
+                        'default': True, 'active': True, 'needs_trigger': False,
+                    },
+                    {
+                        'id': 2, 'type_display_name': 'OneLogin SMS',
+                        'active': True,
+                    },
+                ]
+            }
+        })
+        client = OneLoginClient('cid', 'csecret', region='us')
+        client.access_token = 'tok'
+        devices = client.get_otp_devices(999)
+
+        self.assertEqual(len(devices), 2)
+        self.assertEqual(devices[0].id, 1)
+        self.assertEqual(devices[0].type, 'Google Authenticator')
+        self.assertEqual(devices[0].display_name, 'My Phone')
+        self.assertTrue(devices[0].default)
+        self.assertIsNone(client.error)
+
+    @mock.patch.object(onelogin_client.requests, 'get')
+    def test_filters_out_inactive_devices(self, get):
+        get.return_value = _fake_response(200, {
+            'data': {
+                'otp_devices': [
+                    {'id': 1, 'type_display_name': 'Google Authenticator', 'active': True},
+                    {'id': 2, 'type_display_name': 'OneLogin SMS', 'active': False},
+                ]
+            }
+        })
+        client = OneLoginClient('cid', 'csecret')
+        client.access_token = 'tok'
+        devices = client.get_otp_devices(42)
+
+        self.assertEqual(len(devices), 1)
+        self.assertEqual(devices[0].id, 1)
+
+    @mock.patch.object(onelogin_client.requests, 'get')
+    def test_url_and_bearer_header(self, get):
+        get.return_value = _fake_response(200, {'data': {'otp_devices': []}})
+        client = OneLoginClient('cid', 'csecret', region='eu')
+        client.access_token = 'tok'
+        client.api_configuration['assertion'] = 1
+        client.get_otp_devices(42)
+
+        url = get.call_args[0][0]
+        headers = get.call_args[1]['headers']
+        self.assertEqual(url, 'https://api.eu.onelogin.com/api/1/users/42/otp_devices')
+        self.assertEqual(headers['Authorization'], 'bearer tok')
+
+    @mock.patch.object(onelogin_client.requests, 'get')
+    def test_non_200_sets_error_and_returns_empty(self, get):
+        get.return_value = _fake_response(403, {
+            'status': {'message': 'Forbidden', 'error': True, 'code': 403}
+        })
+        client = OneLoginClient('cid', 'csecret')
+        client.access_token = 'tok'
+        devices = client.get_otp_devices(42)
+
+        self.assertEqual(devices, [])
+        self.assertEqual(client.error, '403')
+        self.assertEqual(client.error_description, 'Forbidden')
+
+    @mock.patch.object(onelogin_client.requests, 'get')
+    def test_malformed_json_returns_empty(self, get):
+        resp = mock.Mock()
+        resp.status_code = 200
+        resp.json.side_effect = ValueError('no json')
+        get.return_value = resp
+        client = OneLoginClient('cid', 'csecret')
+        client.access_token = 'tok'
+
+        self.assertEqual(client.get_otp_devices(42), [])
+
+    @mock.patch.object(onelogin_client.requests, 'get')
+    def test_non_dict_data_returns_empty(self, get):
+        get.return_value = _fake_response(200, {'data': []})
+        client = OneLoginClient('cid', 'csecret')
+        client.access_token = 'tok'
+
+        self.assertEqual(client.get_otp_devices(42), [])
+
+    @mock.patch.object(onelogin_client.requests, 'get')
+    def test_empty_otp_devices_list(self, get):
+        get.return_value = _fake_response(200, {'data': {'otp_devices': []}})
+        client = OneLoginClient('cid', 'csecret')
+        client.access_token = 'tok'
+
+        self.assertEqual(client.get_otp_devices(42), [])
+        self.assertIsNone(client.error)
 
 
 if __name__ == '__main__':

--- a/tests/test_onelogin_client.py
+++ b/tests/test_onelogin_client.py
@@ -321,7 +321,10 @@ class GetOtpDevicesTest(unittest.TestCase):
         get.return_value = _fake_response(200, {'data': {'otp_devices': []}})
         client = OneLoginClient('cid', 'csecret', region='eu')
         client.access_token = 'tok'
-        client.api_configuration['assertion'] = 1
+        # The OTP devices endpoint is a User Management API route, versioned
+        # independently of the SAML assertion API: the URL must stay on v1
+        # regardless of the configured assertion version.
+        client.api_configuration['assertion'] = 2
         client.get_otp_devices(42)
 
         url = get.call_args[0][0]


### PR DESCRIPTION
## Status
**READY**

## Description

This adds the MFA Device label to the table, this is useful for people who have multiple MFA devices of the same type but with custom names, since this uses the `otp_devices` endpoint, the data is a little bit different (the SAML response `type` matches the otp devices `auth_factor_name`)

Before

```
MFA Required
Authenticate using one of these devices:
-----------------------------------------------------------------------
 0 | Google Authenticator
 1 | Google Authenticator
 2 | Yubico YubiKey
-----------------------------------------------------------------------
```

After


```
Authenticate using one of these devices:
-----------------------------------------------------------------------
 0 | Google Authenticator (iOS Authenticator)
 1 | Google Authenticator (1Password)
 2 | Yubico YubiKey (YubiKey)
-----------------------------------------------------------------------
```

I kept the original `type` (which is `auth_factor_name` when using `otp_devices`) to minimize confusion/disorientation for users. The big part is that we've added the custom names for the user

If we wanted to, I can drop the `type` if there's a display name so it matches the OneLogin web ui.



## Deploy Notes

N/A

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```sh
git pull --prune
git checkout de/mfa_names
virtualenv venv
source venv/bin/activate
python setup.py develop
onelogin-aws-assume-role
```

Add your password and see the updated names for MFA
