### PR TITLE
fix: SMS MFA fails when device has a custom display name

### DIFF
--- a/src/aws_assume_role/aws_assume_role.py
+++ b/src/aws_assume_role/aws_assume_role.py
@@ -349,7 +349,7 @@ def get_saml_response(client, username_or_email, password, app_id, onelogin_subd
                         device_selection = 0
                     device = devices[device_selection]
                     device_id = device.id
-                    device_type = device.type
+                    device_type = device.auth_factor_name or device.type
 
                     mfa_verify_info = {
                         'device_id': device_id,

--- a/tests/test_onelogin_client.py
+++ b/tests/test_onelogin_client.py
@@ -157,6 +157,18 @@ class DeviceTest(unittest.TestCase):
         d = Device({'id': 1, 'device_type': 'GoogleAuth', 'type_display_name': 'Google Authenticator'})
         self.assertEqual(d.type, 'GoogleAuth')
 
+    def test_auth_factor_name_stable_when_type_display_name_is_custom(self):
+        d = Device({
+            'id': 2,
+            'type_display_name': 'OneLogin SMS - UK - NEW',
+            'auth_factor_name': 'OneLogin SMS',
+            'active': True,
+            'needs_trigger': True,
+        })
+        self.assertEqual(d.type, 'OneLogin SMS - UK - NEW')
+        self.assertEqual(d.auth_factor_name, 'OneLogin SMS')
+        self.assertTrue(d.needs_trigger)
+
 
 class OneLoginClientHelpersTest(unittest.TestCase):
     def test_subdomain_from_region(self):


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Related PRs
https://github.com/onelogin/onelogin-python-aws-assume-role/pull/98

## Description
OneLogin admins can rename MFA devices to anything they like (e.g. "OneLogin SMS - UK - NEW"). The code was comparing that custom display name against the hardcoded string "OneLogin SMS", which never matched, so the SMS trigger was silently skipped and users were asked for a code that never arrived.

Fixed by using auth_factor_name instead — that's the canonical factor name OneLogin always returns as "OneLogin SMS" regardless of what the device is called in the UI.

## Todos
- [x] Tests
- [x] Documentation


## Deploy Notes
N/A

## Steps to Test or Reproduce
1. Verify that no SMS received when selecting OneLogin SMS
2. 
```sh
git remote add jordanbreen28 https://github.com/jordanbreen28/onelogin-python-aws-assume-role.git
git fetch jordanbreen28
git checkout jordanbreen28/fix-no-sms-received
python -m venv venv
source venv/bin/activate
python setup.py develop
onelogin-aws-assume-role
```
3. Run login flow again, select OneLogin SMS, verify sms received